### PR TITLE
Add timeout for CURL

### DIFF
--- a/src/PhpEws/Ntlm/NtlmSoapClient.php
+++ b/src/PhpEws/Ntlm/NtlmSoapClient.php
@@ -12,6 +12,8 @@ use PhpEws\Exception\EwsException;
  */
 class NtlmSoapClient extends \SoapClient
 {
+    private static $timeout = 30;
+
     /**
      * cURL resource used to make the SOAP request
      *
@@ -63,6 +65,7 @@ class NtlmSoapClient extends \SoapClient
         curl_setopt($this->ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($this->ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM);
         curl_setopt($this->ch, CURLOPT_USERPWD, $this->user.':'.$this->password);
+        curl_setopt($this->ch, CURLOPT_TIMEOUT, self::$timeout);
 
         $response = curl_exec($this->ch);
 
@@ -104,4 +107,16 @@ class NtlmSoapClient extends \SoapClient
 
         return true;
     }
+
+    /**
+     * Set the CURL timeout
+     *
+     * @param int $timeout
+     */
+    public static function setTimeout($timeout)
+    {
+        self::$timeout = $timeout;
+    }
+
+
 }


### PR DESCRIPTION
Hello,

Can you add a timeout for the curl connection because when the URL is wrong the timeout is set to 120 seconds and in a web-app a timeout set to 15-30 seconds is sufficient.